### PR TITLE
Update embeddings.Embedder interface

### DIFF
--- a/embeddings/chromem_ollama.go
+++ b/embeddings/chromem_ollama.go
@@ -53,10 +53,10 @@ func (e *ChromemOllamaEmbedder) Embeddings32(ctx context.Context, content string
 	return e.embeddings_func(ctx, content)
 }
 
-func (e *ChromemOllamaEmbedder) ImageEmbeddings(ctx context.Context, content string) ([]float64, error) {
+func (e *ChromemOllamaEmbedder) ImageEmbeddings(ctx context.Context, data []byte) ([]float64, error) {
 	return nil, dedupe.NotImplemented()
 }
 
-func (e *ChromemOllamaEmbedder) ImageEmbeddings32(ctx context.Context, content string) ([]float32, error) {
+func (e *ChromemOllamaEmbedder) ImageEmbeddings32(ctx context.Context, data []byte) ([]float32, error) {
 	return nil, dedupe.NotImplemented()
 }

--- a/embeddings/embedder.go
+++ b/embeddings/embedder.go
@@ -19,9 +19,9 @@ type Embedder interface {
 	// Embeddings32 returns the embeddings for a string as a list of float32 values.
 	Embeddings32(context.Context, string) ([]float32, error)
 	// ImageEmbeddings returns the embeddings for a base64-encoded image as a list of float64 values.
-	ImageEmbeddings(context.Context, string) ([]float64, error)
+	ImageEmbeddings(context.Context, []byte) ([]float64, error)
 	// ImageEmbeddings32 returns the embeddings for a base64-encoded image as a list of float32 values.
-	ImageEmbeddings32(context.Context, string) ([]float32, error)
+	ImageEmbeddings32(context.Context, []byte) ([]float32, error)
 }
 
 // EmbedderInitializationFunc is a function defined by individual embedder package and used to create

--- a/embeddings/embeddings.go
+++ b/embeddings/embeddings.go
@@ -5,8 +5,20 @@ func asFloat32(data []float64) []float32 {
 	e32 := make([]float32, len(data))
 
 	for idx, v := range data {
+		// Really, check for max float32here...
 		e32[idx] = float32(v)
 	}
 
 	return e32
+}
+
+func asFloat64(data []float32) []float64 {
+
+	e64 := make([]float64, len(data))
+
+	for idx, v := range data {
+		e64[idx] = float64(v)
+	}
+
+	return e64
 }

--- a/embeddings/llamafile_test.go
+++ b/embeddings/llamafile_test.go
@@ -4,7 +4,6 @@ package embeddings
 
 import (
 	"context"
-	"encoding/base64"
 	"io"
 	"os"
 	"testing"
@@ -57,9 +56,7 @@ func TestLlamafileImageEmbeddings(t *testing.T) {
 		t.Fatalf("Failed to read data from %s, %v", im_path, err)
 	}
 
-	im_b64 := base64.StdEncoding.EncodeToString(im_body)
-
-	rsp, err := emb.ImageEmbeddings(ctx, im_b64)
+	rsp, err := emb.ImageEmbeddings(ctx, im_body)
 
 	if err != nil {
 		t.Fatalf("Failed to derive embeddings, %v", err)

--- a/embeddings/ollama.go
+++ b/embeddings/ollama.go
@@ -112,10 +112,10 @@ func (e *OllamaEmbedder) Embeddings32(ctx context.Context, content string) ([]fl
 	return asFloat32(e64), nil
 }
 
-func (e *OllamaEmbedder) ImageEmbeddings(ctx context.Context, content string) ([]float64, error) {
+func (e *OllamaEmbedder) ImageEmbeddings(ctx context.Context, data []byte) ([]float64, error) {
 	return nil, dedupe.NotImplemented()
 }
 
-func (e *OllamaEmbedder) ImageEmbeddings32(ctx context.Context, content string) ([]float32, error) {
+func (e *OllamaEmbedder) ImageEmbeddings32(ctx context.Context, data []byte) ([]float32, error) {
 	return nil, dedupe.NotImplemented()
 }

--- a/embeddings/ollama_test.go
+++ b/embeddings/ollama_test.go
@@ -23,7 +23,9 @@ func TestOllamafileImageEmbeddings(t *testing.T) {
 		t.Fatalf("Failed to create embedder, %v", err)
 	}
 
-	_, err = emb.ImageEmbeddings(ctx, "")
+	var data []byte
+
+	_, err = emb.ImageEmbeddings(ctx, data)
 
 	if !dedupe.IsNotImplementedError(err) {
 		t.Fatalf("Unexpected error, %v", err)


### PR DESCRIPTION
* Update `embeddings.Embedder` interface to require `[]byte` as input for `ImageEmbeddings` methods
* Bug fix: Ensure `LlamafileImageDataEmbeddingRequest.Id` property is `int64` (string values cause `llava-v1.5-7b-q4.llamafile` to crash)
* This release is not backwards compatible